### PR TITLE
Added a function that set any file name when downloading backup data

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ $ docker-compose down -v
 
 ```sh
 $ ./backup
+ => 20190810_011451.tar.bz2
+$ ./backup foo
+ => foo.tar.bz2
 ```
 
 ### Settings (設定する)

--- a/backup
+++ b/backup
@@ -2,7 +2,7 @@
 
 COMPOSE_PREFIX=minecraft-manager-docker
 SRC=data
-DST=`date +%Y%m%d_%H%M%S`.tar.bz2
+DST=${1:-`date +%Y%m%d_%H%M%S`}.tar.bz2
 
 docker-compose down
 docker run --rm -v ${COMPOSE_PREFIX}_minecraft_data:/${SRC} -v $(pwd):/dst alpine tar jcf /dst/${DST} ${SRC}


### PR DESCRIPTION
By specifying an option to the `backup` command, can set an any filename for the backup data to be downloaded.

```sh
$ ./backup kuronekito
```
=> downloaded `kuronekito.tar.bz2`

If omit it option, the current datetime will be applied as the filename.

```sh
$ ./backup
```
=> downloaded `20190810_114514.tar.bz2`

