### PR TITLE
Improved the backup and restore scripts.

### DIFF
--- a/backup
+++ b/backup
@@ -5,5 +5,10 @@ SRC=data
 DST=${1:-`date +%Y%m%d_%H%M%S`}.tar.bz2
 
 docker-compose down
-docker run --rm --mount source=${COMPOSE_PREFIX}_minecraft_data,destination=/${SRC},readonly -v $(pwd):/dst alpine tar jcf /dst/${DST} ${SRC}
+
+TEMP_CONTAINER=$(docker run -itd --mount source=${COMPOSE_PREFIX}_minecraft_data,destination=/${SRC},readonly alpine)
+docker exec ${TEMP_CONTAINER} tar jcvf /root/${DST} ${SRC}
+docker cp ${TEMP_CONTAINER}:/root/${DST} ./
+docker rm -f ${TEMP_CONTAINER}
+
 docker-compose up -d

--- a/restore
+++ b/restore
@@ -18,5 +18,10 @@ COMPOSE_PREFIX=minecraft-manager-docker
 DST=data
 
 docker-compose down
-docker run --rm --mount source=${COMPOSE_PREFIX}_minecraft_data,destination=/${DST} -v $(pwd):/src alpine tar jxf /src/${FILENAME}
+
+TEMP_CONTAINER=$(docker run -itd --mount source=${COMPOSE_PREFIX}_minecraft_data,destination=/${DST} alpine)
+docker cp ./${FILENAME} ${TEMP_CONTAINER}:/root/
+docker exec ${TEMP_CONTAINER} tar jxvf /root/${FILENAME} ${SRC}
+docker rm -f ${TEMP_CONTAINER}
+
 docker-compose up -d


### PR DESCRIPTION
When using this Docker container remotely, volumes across environments cannot be handled properly.
Therefore, moved to the method using `docker cp` command.